### PR TITLE
check stored API key

### DIFF
--- a/d3_armory.js
+++ b/d3_armory.js
@@ -2,7 +2,7 @@ var apiKey = null;
 
 $(function() {
 	apiKey = localStorage.getItem('apiKey');
-	if (!apiKey) {
+	if (!apiKey || apiKey == "null") {
 		apiKey = prompt('Please enter API Key');
 		localStorage.setItem('apiKey', apiKey);
 	}


### PR DESCRIPTION
When cancelling the prompt, storing null in localStorage store the "null" string, which is not null.
